### PR TITLE
refactor: mover gerarMapaFontes para classe GeradorMapaCss

### DIFF
--- a/fontes/foles.ts
+++ b/fontes/foles.ts
@@ -9,6 +9,7 @@ import { ResultadoLexadorInterface, SimboloInterface } from './interfaces';
 import { Tradutor } from "./tradutores/tradutor";
 import { TradutorReverso } from "./tradutores/tradutor-reverso";
 import { Base64 } from "./utilidades/base64";
+import { GeradorMapaCss } from "./gerador-mapa";
 
 /**
  * O núcleo da linguagem FolEs.
@@ -24,6 +25,8 @@ export class FolEs {
     serializadorReverso: SerializadorReverso;
     tradutor: Tradutor;
     tradutorReverso: TradutorReverso;
+    geradorMapaCss: GeradorMapaCss;
+
 
     constructor(traduzirComAninhamentos: boolean) {
         this.lexador = new Lexador();
@@ -37,6 +40,7 @@ export class FolEs {
         this.serializadorReverso = new SerializadorReverso(traduzirComAninhamentos);
         this.tradutor = new Tradutor();
         this.tradutorReverso = new TradutorReverso();
+        this.geradorMapaCss = new GeradorMapaCss();
     }
 
     /**
@@ -70,7 +74,7 @@ export class FolEs {
         const resultadoAvaliadorSintatico = this.avaliadorSintatico.analisar(resultadoLexador[1].simbolos);
         const traducao = this.serializador.serializar(resultadoAvaliadorSintatico);
         const resultadoTraducao = this.tradutor.traduzir(resultadoAvaliadorSintatico);
-        const mapa = this.tradutor.gerarMapaFontes(resultadoTraducao, resultadoLexador[0].join('\n'));
+        const mapa = this.geradorMapaCss.gerarMapaFontes(resultadoTraducao, resultadoLexador[0].join('\n'));
 
         return [
             traducao, 

--- a/fontes/gerador-mapa/index.ts
+++ b/fontes/gerador-mapa/index.ts
@@ -1,3 +1,97 @@
+import * as vlq from 'vlq';
+
+import { Declaracao } from "../declaracoes";
+import { MapaOrigensInterface } from '../interfaces/mapa-origens-interface';
 export class GeradorMapaCss {
-    
+
+    constructor(){}
+    /**
+     * Gera o mapa de fontes (_source map_) de FolEs para CSS.
+     * 
+     * Mapeamentos:
+     * - Primeiro número: coluna no código gerado;
+     * - Segundo número: índice do fonte correspondente listado em "sources" no JSON de mapa;
+     * - Terceiro número: quantas linhas pular para determinar o início do símbolo no código original;
+     * - Quarto número: coluna no código original.
+     * 
+     * @param declaracoes As declarações já traduzidas.
+     * @returns {MapaOrigensInterface} O mapa de origens pronto.
+     */
+    gerarMapaFontes(declaracoes: Declaracao[], conteudoArquivoOriginal: string): MapaOrigensInterface {
+        
+        const retorno: MapaOrigensInterface = {
+            version: 3,
+            file: "teste.css",
+            sourceRoot: "",
+            sources: [
+                "teste.foles"
+            ],
+            sourcesContent: [conteudoArquivoOriginal],
+            mappings: ""
+        };
+
+        for (const declaracao of declaracoes) {
+            for (const seletor of declaracao.seletores) {
+                const pragmasFoles = seletor.pragmas;
+                const pragmasCss = seletor.pragmasTraducao;
+
+                retorno.mappings += vlq.encode([
+                    pragmasCss.colunaInicial - 1, 
+                    0, 
+                    0, 
+                    pragmasFoles.colunaInicial - 1
+                ]) + ',';
+
+                // Pragma de vírgula.
+                retorno.mappings += vlq.encode([
+                    pragmasCss.colunaFinal, 
+                    0, 
+                    0, 
+                    pragmasFoles.colunaFinal
+                ]) + ',';
+            }
+
+            retorno.mappings = retorno.mappings.slice(0, -1) + ';';
+
+            for (const modificador of declaracao.modificadores) {
+                const pragmasFoles = modificador.pragmas;
+                const pragmasCss = modificador.pragmasTraducao;
+
+                // Pragma do modificador em si
+                retorno.mappings += vlq.encode([
+                    pragmasCss.colunaInicial - 1, 
+                    0, 
+                    1, 
+                    (pragmasFoles.colunaInicial - 1) - (pragmasCss.colunaInicial - 1)
+                ]) + ',';
+
+                retorno.mappings += vlq.encode([
+                    pragmasCss.colunaFinal - 4, 
+                    0, 
+                    0, 
+                    pragmasFoles.colunaFinal - 4
+                ]) + ',';
+
+                // Pragma do dois-pontos.
+                retorno.mappings += vlq.encode([
+                    2, 
+                    0, 
+                    0, 
+                    2
+                ]) + ',';
+
+                const larguraValor = modificador.valor.toString().length + modificador.quantificador.length;
+
+                // Pragma do valor.
+                retorno.mappings += vlq.encode([
+                    larguraValor, 
+                    0, 
+                    0, 
+                    larguraValor
+                ]) + ';';
+            }
+        }
+
+        return retorno;
+    }
 }

--- a/fontes/tradutores/tradutor.ts
+++ b/fontes/tradutores/tradutor.ts
@@ -8,7 +8,7 @@ import { PragmasSeletor, Seletor, SeletorEstrutura } from "../seletores";
 import { Metodo } from "../valores/metodos/metodo";
 
 import estruturasHtml from "./estruturas-html";
-import { MapaOrigensInterface } from '../interfaces/mapa-origens-interface';
+
 
 export class Tradutor {
     linha: number;
@@ -105,93 +105,4 @@ export class Tradutor {
         return declaracoesTraduzidas;
     }
 
-    /**
-     * Gera o mapa de fontes (_source map_) de FolEs para CSS.
-     * 
-     * Mapeamentos:
-     * - Primeiro número: coluna no código gerado;
-     * - Segundo número: índice do fonte correspondente listado em "sources" no JSON de mapa;
-     * - Terceiro número: quantas linhas pular para determinar o início do símbolo no código original;
-     * - Quarto número: coluna no código original.
-     * 
-     * @param declaracoes As declarações já traduzidas.
-     * @returns {MapaOrigensInterface} O mapa de origens pronto.
-     */
-    gerarMapaFontes(declaracoes: Declaracao[], conteudoArquivoOriginal: string): MapaOrigensInterface {
-
-        const retorno: MapaOrigensInterface = {
-            version: 3,
-            file: "teste.css",
-            sourceRoot: "",
-            sources: [
-                "teste.foles"
-            ],
-            sourcesContent: [conteudoArquivoOriginal],
-            mappings: ""
-        };
-
-        for (const declaracao of declaracoes) {
-            for (const seletor of declaracao.seletores) {
-                const pragmasFoles = seletor.pragmas;
-                const pragmasCss = seletor.pragmasTraducao;
-
-                retorno.mappings += vlq.encode([
-                    pragmasCss.colunaInicial - 1, 
-                    0, 
-                    0, 
-                    pragmasFoles.colunaInicial - 1
-                ]) + ',';
-
-                // Pragma de vírgula.
-                retorno.mappings += vlq.encode([
-                    pragmasCss.colunaFinal, 
-                    0, 
-                    0, 
-                    pragmasFoles.colunaFinal
-                ]) + ',';
-            }
-
-            retorno.mappings = retorno.mappings.slice(0, -1) + ';';
-
-            for (const modificador of declaracao.modificadores) {
-                const pragmasFoles = modificador.pragmas;
-                const pragmasCss = modificador.pragmasTraducao;
-
-                // Pragma do modificador em si
-                retorno.mappings += vlq.encode([
-                    pragmasCss.colunaInicial - 1, 
-                    0, 
-                    1, 
-                    (pragmasFoles.colunaInicial - 1) - (pragmasCss.colunaInicial - 1)
-                ]) + ',';
-
-                retorno.mappings += vlq.encode([
-                    pragmasCss.colunaFinal - 4, 
-                    0, 
-                    0, 
-                    pragmasFoles.colunaFinal - 4
-                ]) + ',';
-
-                // Pragma do dois-pontos.
-                retorno.mappings += vlq.encode([
-                    2, 
-                    0, 
-                    0, 
-                    2
-                ]) + ',';
-
-                const larguraValor = modificador.valor.toString().length + modificador.quantificador.length;
-
-                // Pragma do valor.
-                retorno.mappings += vlq.encode([
-                    larguraValor, 
-                    0, 
-                    0, 
-                    larguraValor
-                ]) + ';';
-            }
-        }
-
-        return retorno;
-    }
 }

--- a/testes/tradutor.test.ts
+++ b/testes/tradutor.test.ts
@@ -5,18 +5,21 @@ import { Importador } from "../fontes/importador";
 import { AvaliadorSintaticoInterface, ImportadorInterface, LexadorInterface } from "../fontes/interfaces";
 import { Lexador } from "../fontes/lexador";
 import { Tradutor } from "../fontes/tradutores/tradutor";
+import {GeradorMapaCss} from "../fontes/gerador-mapa"
 
 describe('Tradutor', () => {
     let lexador: LexadorInterface;
     let importador: ImportadorInterface;
     let avaliador: AvaliadorSintaticoInterface;
     let tradutor: Tradutor;
+    let geradorMapaCss: GeradorMapaCss;
 
     beforeEach(() => {
         lexador = new Lexador();
         importador = new Importador(lexador);
         avaliador = new AvaliadorSintatico(importador);
         tradutor = new Tradutor();
+        geradorMapaCss = new GeradorMapaCss;
     });
 
     describe('Tradução', () => {
@@ -47,7 +50,7 @@ describe('Tradutor', () => {
 
             const resultadoAvaliadorSintatico = avaliador.analisar(resultadoLexador.simbolos);
             const resultadoTraducao = tradutor.traduzir(resultadoAvaliadorSintatico);
-            const resultado = tradutor.gerarMapaFontes(resultadoTraducao, fonteOriginal.join('\n'));
+            const resultado = geradorMapaCss.gerarMapaFontes(resultadoTraducao, fonteOriginal.join('\n'));
 
             /* 
             for (const linha of resultado.mappings.split(';')) {


### PR DESCRIPTION
  - Migrei o método gerarMapaFontes de fontes/tradutores/tradutor.ts para a nova classe GeradorMapaCss em fontes/gerador-mapas/index.ts Conforme pedido na Issue.
  - Atualizei as chamadas para o método em fontes/foles.ts e tradutor.test.ts. 
  - Todos os testes unitários foram executados e passaram com sucesso.
  