### PR TITLE
314: remover ponto e vírgula duplicado no lexador

### DIFF
--- a/fontes/lexador/lexador-reverso.ts
+++ b/fontes/lexador/lexador-reverso.ts
@@ -221,7 +221,6 @@ export class LexadorReverso implements LexadorInterface {
             case "\0":
             case "\r":
             case "\t":
-            case ";":
                 this.avancar();
                 break;
             default:

--- a/fontes/lexador/lexador.ts
+++ b/fontes/lexador/lexador.ts
@@ -327,7 +327,6 @@ export class Lexador implements LexadorInterface {
             case "\0":
             case "\r":
             case "\t":
-            case ";":
                 this.avancar();
                 break;
             case "/":


### PR DESCRIPTION
## O que foi alterado

* Removido o `case ";"` duplicado em `fontes/lexador/lexador.ts`.
* Removido o `case ";"` duplicado em `fontes/lexador/lexador-reverso.ts`.
* Mantido o tratamento dos caracteres de whitespace, que compartilham a lógica de ignorar o caractere e avançar.

## Motivo da mudança

O ESLint identificou os `case ";"` duplicados através da regra `no-duplicate-case`. O primeiro `case ";"` já realiza o tratamento correto, gerando um `PONTO_E_VIRGULA`. O segundo estava agrupado aos cases de whitespace sem necessidade.

## Resultado

* `no-duplicate-case` corrigido nos dois lexadores.
* Testes unitários passando sem regressões.
* Comportamento dos whitespaces preservado.
<img width="586" height="214" alt="image" src="https://github.com/user-attachments/assets/79dbc985-abb3-4c73-b125-ef553e4edf66" />

## Issue relacionada

Resolve #314